### PR TITLE
Fix Harbor incompatibility

### DIFF
--- a/internal/plugins/harbor-provisioner.go
+++ b/internal/plugins/harbor-provisioner.go
@@ -6,7 +6,6 @@ package plugins
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"strings"
 	"time"
 
@@ -17,8 +16,9 @@ type Harbor interface {
 	Configurations(ctx context.Context) error
 	CreateProject(ctx context.Context, org string, displayName string) error
 	SetMemberPermissions(ctx context.Context, roleID int, org string, displayName string, groupName string) error
-	CreateRobot(ctx context.Context, robotName string, org string, displayName string) (string, string, int, error)
-	GetRobot(ctx context.Context, org string, displayName string, robotName string) (*southbound.HarborRobot, error)
+	CreateRobot(ctx context.Context, robotName string, org string, displayName string) (string, string, error)
+	GetProjectID(ctx context.Context, org string, displayName string) (int, error)
+	GetRobot(ctx context.Context, org string, displayName string, robotName string, projectID int) (*southbound.HarborRobot, error)
 	DeleteRobot(ctx context.Context, org string, displayName string, robotID int) error
 	DeleteProject(ctx context.Context, org string, displayName string) error
 	Ping(ctx context.Context) error
@@ -100,11 +100,12 @@ func (p *HarborProvisionerPlugin) CreateEvent(ctx context.Context, event Event, 
 		return err
 	}
 
-	/* Leaving this check in because it was known to work for older harbor versions.
-	 * On the current Harbot version it is returning a 404 because the /projects/{project_name}/robots endpoint does not exist.
-	 * TODO: Delete this code when appropriate.
-	 */
-	robot, _ := p.harbor.GetRobot(ctx, org, name, "catalog-apps-read-write")
+	projectID, err := p.harbor.GetProjectID(ctx, org, name)
+	if err != nil {
+		return err
+	}
+
+	robot, _ := p.harbor.GetRobot(ctx, org, name, "catalog-apps-read-write", projectID)
 	if robot != nil {
 		err = p.harbor.DeleteRobot(ctx, org, name, robot.ID)
 		if err != nil {
@@ -112,20 +113,8 @@ func (p *HarborProvisionerPlugin) CreateEvent(ctx context.Context, event Event, 
 		}
 	}
 
-	var secret string
-	var statusCode int
-	name, secret, statusCode, err = p.harbor.CreateRobot(ctx, `catalog-apps-read-write`, org, name)
-	if err != nil && statusCode == http.StatusConflict {
-		log.Info("Robot already exists, trying to delete and recreate")
-		err = p.harbor.DeleteRobot(ctx, org, name, robot.ID)
-		if err != nil {
-			return err
-		}
-		name, secret, statusCode, err = p.harbor.CreateRobot(ctx, `catalog-apps-read-write`, org, name)
-		if err != nil {
-			return err
-		}
-	} else if err != nil {
+	name, secret, err := p.harbor.CreateRobot(ctx, `catalog-apps-read-write`, org, name)
+	if err != nil {
 		return err
 	}
 

--- a/internal/plugins/mock-clients_test.go
+++ b/internal/plugins/mock-clients_test.go
@@ -183,9 +183,13 @@ func (t *testHarbor) Ping(_ context.Context) error {
 	return nil
 }
 
+func (t *testHarbor) GetProjectID(_ context.Context, _ string, _ string) (int, error) {
+	return 0, nil
+}
+
 var nextRobotID = 1
 
-func (t *testHarbor) CreateRobot(_ context.Context, robotName string, org string, displayName string) (string, string, int, error) {
+func (t *testHarbor) CreateRobot(_ context.Context, robotName string, org string, displayName string) (string, string, error) {
 	// robot$catalog-apps-coke-proj1+catalog-apps-read-write
 	robotName = fmt.Sprintf("robot$catalog-apps-%s-%s+%s", org, displayName, robotName)
 	t.robots[robotName] = robot{
@@ -194,10 +198,11 @@ func (t *testHarbor) CreateRobot(_ context.Context, robotName string, org string
 		robotID:     nextRobotID,
 	}
 	nextRobotID++
-	return "name", "secret", 0, nil
+	return "name", "secret", nil
 }
 
-func (t *testHarbor) GetRobot(_ context.Context, _ string, _ string, robotName string) (*southbound.HarborRobot, error) {
+func (t *testHarbor) GetRobot(_ context.Context, _ string, _ string, robotName string, projectID int) (*southbound.HarborRobot, error) {
+	_ = projectID // TODO: fix up mock to include projectID
 	r, ok := t.robots[robotName]
 	if !ok {
 		return nil, fmt.Errorf("robot %s not found", robotName)

--- a/internal/plugins/mock-clients_test.go
+++ b/internal/plugins/mock-clients_test.go
@@ -6,11 +6,12 @@ package plugins
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/open-edge-platform/app-orch-tenant-controller/internal/config"
 	"github.com/open-edge-platform/app-orch-tenant-controller/internal/southbound"
 	"oras.land/oras-go/v2/content/file"
-	"os"
-	"path/filepath"
 )
 
 // Catalog client mock
@@ -184,7 +185,7 @@ func (t *testHarbor) Ping(_ context.Context) error {
 
 var nextRobotID = 1
 
-func (t *testHarbor) CreateRobot(_ context.Context, robotName string, org string, displayName string) (string, string, error) {
+func (t *testHarbor) CreateRobot(_ context.Context, robotName string, org string, displayName string) (string, string, int, error) {
 	// robot$catalog-apps-coke-proj1+catalog-apps-read-write
 	robotName = fmt.Sprintf("robot$catalog-apps-%s-%s+%s", org, displayName, robotName)
 	t.robots[robotName] = robot{
@@ -193,7 +194,7 @@ func (t *testHarbor) CreateRobot(_ context.Context, robotName string, org string
 		robotID:     nextRobotID,
 	}
 	nextRobotID++
-	return "name", "secret", nil
+	return "name", "secret", 0, nil
 }
 
 func (t *testHarbor) GetRobot(_ context.Context, _ string, _ string, robotName string) (*southbound.HarborRobot, error) {

--- a/internal/southbound/harbor.go
+++ b/internal/southbound/harbor.go
@@ -376,7 +376,9 @@ func (h *HarborOCI) GetRobot(ctx context.Context, org string, displayName string
 }
 
 func (h *HarborOCI) DeleteRobot(ctx context.Context, org string, displayName string, robotID int) error {
-	URL := fmt.Sprintf("%s/api/v2.0/projects/%s/robots/%d", h.harborHost, HarborProjectName(org, displayName), robotID)
+	_ = org
+	_ = displayName
+	URL := fmt.Sprintf("%s/api/v2.0/robots/%d", h.harborHost, robotID)
 	resp, err := h.doHarborREST(ctx, http.MethodDelete, URL, nil, AddHeaders)
 	if err != nil {
 		return err

--- a/internal/southbound/harbor_test.go
+++ b/internal/southbound/harbor_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/suite"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -15,6 +14,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/suite"
 )
 
 // Suite of harbor southbound tests
@@ -273,7 +274,7 @@ func (s *HarborTestSuite) TestHarborCreateRobot() {
 	h, err := newHarbor(s.ctx, s.testServer.Server.URL, "OIDC", "harbor", "credential")
 	s.NoError(err)
 
-	name, secret, err := h.CreateRobot(s.ctx, "new-robot", "org", "new-project")
+	name, secret, _, err := h.CreateRobot(s.ctx, "new-robot", "org", "new-project")
 	s.NoError(err)
 	s.Equal("robot$catalog-apps-org-new-project+new-robot", name)
 	s.Equal("super-sekret-shhh", secret)


### PR DESCRIPTION
## Description

The harbor API for project robots -- projects/<name>/robots was dropped, and tenant controller was no longer compatible. The GetRobot and DeleteRobot APIs had to be updated.

## Checklist

- [ ] Tests passed
- [ ] Documentation updated
