### PR TITLE
Enable post-merge security scans for tag creation

### DIFF
--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -9,6 +9,8 @@ on:
     branches:
       - main
       - release-*
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow configuration. The change ensures that the `post-merge.yaml` workflow will also trigger on any tag push, in addition to the existing triggers for the `main` and `release-*` branches.

* Updated the `on:` section in `.github/workflows/post-merge.yaml` to trigger the workflow on any tag push.